### PR TITLE
Trigger blur manually and more errors

### DIFF
--- a/jquery.placeholder.js
+++ b/jquery.placeholder.js
@@ -138,6 +138,7 @@
         var $input = $(input);
         if (input.value == $input.attr('placeholder') && $input.hasClass(settings.customClass)) {
             if ($input.data('placeholder-password')) {
+
                 $input = $input.hide().nextAll('input[type="password"]:first').show().attr('id', $input.removeAttr('id').data('placeholder-id'));
                 // If `clearPlaceholder` was called from `$.valHooks.input.set`
                 if (event === true) {
@@ -152,11 +153,25 @@
         }
     }
 
-    function setPlaceholder() {
+    function setPlaceholder(event) {
         var $replacement;
         var input = this;
         var $input = $(input);
         var id = this.id;
+
+        // If the placeholder is activated, triggering blur event (`$input.trigger('blur')`) should do nothing.
+        if (event && event.type === 'blur') {
+            if ($input.hasClass(settings.customClass)) {
+                return;
+            }
+            if (input.type === 'password') {
+                $replacement = $input.prevAll('input[type="text"]:first');
+                if ($replacement.length > 0 && $replacement.is(':visible')) {
+                    return;
+                }
+            }
+        }
+
         if (input.value === '') {
             if (input.type === 'password') {
                 if (!$input.data('placeholder-textinput')) {

--- a/jquery.placeholder.js
+++ b/jquery.placeholder.js
@@ -176,7 +176,7 @@
             if (input.type === 'password') {
                 if (!$input.data('placeholder-textinput')) {
                     try {
-                        $replacement = $input.clone().attr({ 'type': 'text' });
+                        $replacement = $input.clone().prop({ 'type': 'text' });
                     } catch(e) {
                         $replacement = $('<input>').attr($.extend(args(this), { 'type': 'text' }));
                     }


### PR DESCRIPTION
- Trigger blur event manually.
- Fix the password input dot problem in IE7/8 simulated by IE9+.
- Fix `set` hooks chainability and `clearPlaceholder` problem for the password input.